### PR TITLE
script command implementation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ compiling, and deploying your smart contracts easy.
  - [Deployment](deployment.md)
  - [Templates](templates.md)
  - [Testing](testing.md)
+ - [Scripts](script.md)
  - [metafile.json](metafile.md) - The JSON file that contains information about deployments and project state
  - [networks.yml](networks.md) - The Ethereum JSON-RPC network configuration file
  - [SolidByte Development](development.md)

--- a/docs/script.md
+++ b/docs/script.md
@@ -1,0 +1,23 @@
+# Scripts
+
+## Overview
+
+You can create scrpits that can be run by solidbyte. Solidbyte will provide
+these scripts with some useful things, like an instantiated `Web3` object and
+`web3.eth.Contract` representations of your smart contracts.
+
+There's no reason it's necessary to create scripts this way, but it's intended
+to make things easier.
+
+## Script Implementations
+
+For example scripts, see the [scripts directory of the solidbyte-test-project
+repository](https://github.com/mikeshultz/solidbyte-test-project/tree/master/scripts).
+
+The only thing that is required to run your scripts via the `sb script` command
+is that you implement the `main()` function.  The following kwargs will be
+provided if you include them in your function definition:
+
+- `network` - The name of the network used in the CLI command
+- `contracts` - An `AttrDict` of your deployed contracts.
+- `web3` - An instantiated Web3 object.

--- a/solidbyte/cli/handler.py
+++ b/solidbyte/cli/handler.py
@@ -21,6 +21,7 @@ MODULES = [
     'install',
     'metafile',
     'sigs',
+    'script',
 ]
 
 IMPORTED_MODULES = {}

--- a/solidbyte/cli/script.py
+++ b/solidbyte/cli/script.py
@@ -1,0 +1,37 @@
+""" Run user scripts
+"""
+import sys
+from ..script import run_scripts
+from ..common.utils import collapse_oel
+from ..common.logging import getLogger
+
+log = getLogger(__name__)
+
+
+def add_parser_arguments(parser):
+    """ Add additional subcommands onto this command """
+    parser.add_argument('network', metavar="NETWORK", type=str, nargs=1,
+                        help='Ethereum network to connect the console to')
+    parser.add_argument('script', metavar="FILE", type=str, nargs='+',
+                        help='Script to run')
+    return parser
+
+
+def main(parser_args):
+    """ Execute test """
+
+    scripts_plural = 's' if len(parser_args.script) > 1 else ''
+
+    log.info("Running script{} {}".format(
+        scripts_plural,
+        ', '.join(parser_args.script))
+    )
+
+    res = run_scripts(collapse_oel(parser_args.network), parser_args.script)
+
+    if not res:
+        log.error("Script{} returned error".format(scripts_plural))
+        sys.exit(1)
+
+    log.info("Script{} run successfully".format(scripts_plural))
+    sys.exit()

--- a/solidbyte/common/exceptions.py
+++ b/solidbyte/common/exceptions.py
@@ -8,3 +8,5 @@ class ConfigurationError(SolidbyteException): pass
 class AccountError(SolidbyteException): pass
 class ValidationError(SolidbyteException): pass
 class WrongPassword(ValidationError): pass
+class ScriptError(SolidbyteException): pass
+class InvalidScriptError(ValidationError): pass

--- a/solidbyte/script/__init__.py
+++ b/solidbyte/script/__init__.py
@@ -60,7 +60,6 @@ def run_script(network: str, script: str) -> bool:
     spec.loader.exec_module(mod)
 
     if not hasattr(mod, 'main'):
-        print("MOD", dir(mod))
         raise InvalidScriptError("Function main() must be defined in script")
 
     func_spec = inspect.getfullargspec(mod.main)

--- a/solidbyte/script/__init__.py
+++ b/solidbyte/script/__init__.py
@@ -1,0 +1,102 @@
+""" Functionality for running user scripts """
+import inspect
+from types import ModuleType
+from typing import Optional, List
+from attrdict import AttrDict
+# from importlib import SourceFileLoader
+# from importlib.abc import SourceLoader
+from importlib.util import spec_from_file_location, module_from_spec
+from ..deploy import Deployer
+from ..common.utils import to_path
+from ..common.web3 import web3c
+from ..common.exceptions import InvalidScriptError
+from ..common.logging import getLogger
+
+log = getLogger(__name__)
+deployer: Optional[Deployer] = None
+
+
+def get_contracts(network):
+    """ Get a list of web3 contract instances. """
+    global deployer
+
+    if not deployer:
+        deployer = Deployer(network_name=network)
+
+    contracts = AttrDict({})
+
+    for contract_name, contract in deployer.contracts.items():
+        try:
+            # TODO: Internal API?  Better option?
+            contracts[contract_name] = contract._get_web3_contract()
+        except AssertionError:
+            log.warning("Unable to get a deployed instance for contract {}".format(contract_name))
+
+    return contracts
+
+
+def get_availble_script_kwargs(network):
+    global deployer
+
+    if not deployer:
+        deployer = Deployer(network_name=network)
+
+    contracts = get_contracts(network)
+
+    return {
+        'web3': web3c.get_web3(network),
+        'contracts': contracts,
+        'deployer_account': deployer.account,
+        'network': network,
+    }
+
+
+def run_script(network: str, script: str) -> bool:
+    """ Runs a user script """
+
+    scriptPath = to_path(script)
+    script_kwargs = get_availble_script_kwargs(network)
+
+    spec = spec_from_file_location(scriptPath.name[:-3], str(scriptPath))
+    mod: Optional[ModuleType] = module_from_spec(spec)
+
+    # try:
+    #     log.debug("Loading deploy script {}".format(scriptPath))
+    #     mod = SourceFileLoader(scriptPath.name[:-3], str(scriptPath)).exec_module()
+    # except ModuleNotFoundError as e:
+    #     if str(e) == "No module named 'deploy'":
+    #         raise ScriptError(
+    #                 "Unable to import script."
+    #             )
+    #     else:
+    #         raise e
+
+    if not spec or not spec.loader or not mod:
+        raise InvalidScriptError("Script not found")
+
+    spec.loader.exec_module(mod)
+
+    if not hasattr(mod, 'main'):
+        print("MOD", dir(mod))
+        raise InvalidScriptError("Function main() must be defined in script")
+
+    func_spec = inspect.getfullargspec(mod.main)
+    script_kwargs = {k: script_kwargs.get(k) for k in func_spec.args}
+    retval = mod.main(**script_kwargs)
+
+    # If a script choses to return False, they're signalling a failure
+    if retval is False:
+        log.error("Script has indicated an error!")
+        return False
+
+    return True
+
+
+def run_scripts(network: str, scripts: List[str]) -> bool:
+    """ Run multiple user scripts """
+
+    if len(scripts) < 1:
+        log.warning("No scripts provided")
+        return True
+
+    return all([run_script(network, script) for script in scripts])

--- a/solidbyte/script/__init__.py
+++ b/solidbyte/script/__init__.py
@@ -4,7 +4,6 @@ from types import ModuleType
 from typing import Optional, Any, Dict, List
 from attrdict import AttrDict
 from importlib.util import spec_from_file_location, module_from_spec
-from web3.eth import Contract as Web3Contract
 from ..deploy import Deployer
 from ..deploy.objects import Contract
 from ..common.utils import Path, to_path

--- a/solidbyte/templates/template.py
+++ b/solidbyte/templates/template.py
@@ -37,6 +37,7 @@ class Template(object):
         tests_dir = self.pwd.joinpath('tests')
         contracts_dir = self.pwd.joinpath('contracts')
         deploy_dir = self.pwd.joinpath('deploy')
+        scripts_dir = self.pwd.joinpath('scripts')
 
         if tests_dir.exists() \
                 or contracts_dir.exists() \
@@ -55,3 +56,6 @@ class Template(object):
 
         log.debug("Creating deploy directory...")
         deploy_dir.mkdir(mode=self.dir_mode)
+
+        log.debug("Creating scripts directory...")
+        scripts_dir.mkdir(mode=self.dir_mode)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def mock_project():
                         'contracts': project_dir.joinpath('contracts'),
                         'deploy': project_dir.joinpath('deploy'),
                         'build': project_dir.joinpath('build'),
+                        'scripts': project_dir.joinpath('scripts'),
                         'networksyml': project_dir.joinpath('networks.yml'),
                     })
             })

--- a/tests/const.py
+++ b/tests/const.py
@@ -475,3 +475,11 @@ def main(contracts):
     return False
 
 """
+
+USER_SCRIPT_INVALID = """
+
+# This is invalid
+def main_func(contracts):
+    return False
+
+"""

--- a/tests/const.py
+++ b/tests/const.py
@@ -459,3 +459,19 @@ def main(contracts, deployer_account, web3, network):
     assert test.functions.sub(6, 3).call() == 3
     return True
 """
+
+USER_SCRIPT_1 = """
+
+def main(contracts):
+    print(contracts)
+    test = contracts.get('Test')
+    return test is not None and test.address is not None
+
+"""
+
+USER_SCRIPT_FAIL = """
+
+def main(contracts):
+    return False
+
+"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,25 @@ def test_cli_integration(mock_project):
         # test `sb metafile cleanup`
         execute_command_assert_no_error_success([sb, 'metafile', 'cleanup'])
 
+        # test `sb deploy -a ADDRESS NETWORK`
+        # execute_command_assert_no_error_success([
+        #     sb,
+        #     'deploy',
+        #     '-a',
+        #     default_account,
+        #     'test',
+        # ])
+
+        # test `sb script NETWORK FILE`
+        # TODO: There's currently no persistance between the deploy command and the following
+        #       commands.  Might need to use ganache to test with instead of eth_tester.
+        # execute_command_assert_no_error_success([
+        #     sb,
+        #     'script',
+        #     'test',
+        #     'scripts/test_success.py',
+        # ])
+
     # Create a new project without the mock
     project_dir = TMP_DIR.joinpath('test-cli-init')
     project_dir.mkdir()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,98 @@
+""" Tests for script command """
+from web3.eth import Contract as Web3Contract
+from solidbyte.common.web3 import web3c
+from solidbyte.deploy import Deployer
+from solidbyte.compile.compiler import Compiler
+from solidbyte.script import get_contracts, run_script, run_scripts
+from .const import (
+    NETWORK_NAME,
+)
+
+
+def test_get_contracts(mock_project):
+    """ Test that get_contracts() returns proper Web3 contract objects """
+    with mock_project() as mock:
+
+        # Setup our environment
+        compiler = Compiler(project_dir=mock.paths.project)
+        compiler.compile_all()
+
+        # Since we're not using the pwd, we need to use this undocumented API (I know...)
+        web3c._load_configuration(mock.paths.networksyml)
+        web3 = web3c.get_web3(NETWORK_NAME)
+
+        deployer_account = web3.eth.accounts[0]
+
+        # Init the Deployer
+        d = Deployer(
+            network_name=NETWORK_NAME,
+            account=deployer_account,
+            project_dir=mock.paths.project,
+        )
+        d.deploy()
+
+        contracts = get_contracts(NETWORK_NAME)
+        assert len(contracts) > 0, "No contracts found"
+
+        # Make sure it has all the expected Web3 Contract props
+        assert hasattr(contracts['Test'], 'functions')
+        assert hasattr(contracts['Test'], 'address')
+        assert hasattr(contracts['Test'], 'abi')
+
+
+def test_script(mock_project):
+    """ test user  script running """
+
+    with mock_project() as mock:
+        test_script = mock.paths.scripts.joinpath('test_success.py')
+        assert test_script.is_file()
+
+        # Setup our environment
+        compiler = Compiler(project_dir=mock.paths.project)
+        compiler.compile_all()
+
+        # Since we're not using the pwd, we need to use this undocumented API (I know...)
+        web3c._load_configuration(mock.paths.networksyml)
+        web3 = web3c.get_web3(NETWORK_NAME)
+
+        deployer_account = web3.eth.accounts[0]
+
+        # Init the Deployer
+        d = Deployer(
+            network_name=NETWORK_NAME,
+            account=deployer_account,
+            project_dir=mock.paths.project,
+        )
+        d.deploy()
+
+        assert run_script(NETWORK_NAME, str(test_script)), "Script unexpectedly failed"
+        assert run_scripts(NETWORK_NAME, [str(test_script)]), "Scripts unexpectedly failed"
+
+
+def test_script_failure(mock_project):
+    """ test that scripts fail properly """
+
+    with mock_project() as mock:
+        test_script = mock.paths.scripts.joinpath('test_fail.py')
+        assert test_script.is_file()
+
+        # Setup our environment
+        compiler = Compiler(project_dir=mock.paths.project)
+        compiler.compile_all()
+
+        # Since we're not using the pwd, we need to use this undocumented API (I know...)
+        web3c._load_configuration(mock.paths.networksyml)
+        web3 = web3c.get_web3(NETWORK_NAME)
+
+        deployer_account = web3.eth.accounts[0]
+
+        # Init the Deployer
+        d = Deployer(
+            network_name=NETWORK_NAME,
+            account=deployer_account,
+            project_dir=mock.paths.project,
+        )
+        d.deploy()
+
+        assert run_script(NETWORK_NAME, str(test_script)) is False, "Script unexpectedly succeeded"
+        assert run_scripts(NETWORK_NAME, [str(test_script)]) is False, "Scripts unexpectedly succeeded"

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -121,4 +121,9 @@ def test_invalid_script(mock_project):
         except InvalidScriptError:
             pass
 
-        assert run_scripts(NETWORK_NAME, []) is False
+
+def test_no_scripts(mock_project):
+    """ test that no scripts doesn't fail """
+
+    with mock_project() as mock:
+        assert run_scripts(NETWORK_NAME, [])

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,4 @@
 """ Tests for script command """
-from web3.eth import Contract as Web3Contract
 from solidbyte.common.web3 import web3c
 from solidbyte.deploy import Deployer
 from solidbyte.compile.compiler import Compiler
@@ -95,4 +94,6 @@ def test_script_failure(mock_project):
         d.deploy()
 
         assert run_script(NETWORK_NAME, str(test_script)) is False, "Script unexpectedly succeeded"
-        assert run_scripts(NETWORK_NAME, [str(test_script)]) is False, "Scripts unexpectedly succeeded"
+        assert run_scripts(NETWORK_NAME, [str(test_script)]) is False, (
+            "Scripts unexpectedly succeeded"
+        )

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,6 @@
 """ Tests for script command """
 from solidbyte.common.web3 import web3c
+from solidbyte.common.exceptions import InvalidScriptError
 from solidbyte.deploy import Deployer
 from solidbyte.compile.compiler import Compiler
 from solidbyte.script import get_contracts, run_script, run_scripts
@@ -97,3 +98,27 @@ def test_script_failure(mock_project):
         assert run_scripts(NETWORK_NAME, [str(test_script)]) is False, (
             "Scripts unexpectedly succeeded"
         )
+
+
+def test_invalid_script(mock_project):
+    """ test that invalid scripts fail """
+
+    with mock_project() as mock:
+        test_script = mock.paths.scripts.joinpath('test_nothing.py')
+        assert not test_script.is_file()
+        invalid_script = mock.paths.scripts.joinpath('test_invalid.py')
+        assert invalid_script.is_file()
+
+        try:
+            run_script(NETWORK_NAME, test_script)
+            assert False, "Should have thrown an error"
+        except FileNotFoundError:
+            pass
+
+        try:
+            run_script(NETWORK_NAME, invalid_script)
+            assert False, "Should have thrown an error"
+        except InvalidScriptError:
+            pass
+
+        assert run_scripts(NETWORK_NAME, []) is False

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -125,5 +125,4 @@ def test_invalid_script(mock_project):
 def test_no_scripts(mock_project):
     """ test that no scripts doesn't fail """
 
-    with mock_project() as mock:
-        assert run_scripts(NETWORK_NAME, [])
+    assert run_scripts(NETWORK_NAME, [])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,7 @@ from .const import (
     LIBRARY_SOURCE_FILE_3,
     USER_SCRIPT_1,
     USER_SCRIPT_FAIL,
+    USER_SCRIPT_INVALID,
 )
 
 RECURSUION_MAX = 15
@@ -90,6 +91,7 @@ def create_mock_project(project_dir):
     write_temp_file(PYTEST_TEST_1, 'test_testing.py', test_dir)
     write_temp_file(USER_SCRIPT_1, 'test_success.py', scripts_dir)
     write_temp_file(USER_SCRIPT_FAIL, 'test_fail.py', scripts_dir)
+    write_temp_file(USER_SCRIPT_INVALID, 'test_invalid.py', scripts_dir)
 
 
 def create_mock_project_with_libraries(project_dir):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,6 +15,8 @@ from .const import (
     CONTRACT_SOURCE_FILE_2,
     LIBRARY_SOURCE_FILE_1,
     LIBRARY_SOURCE_FILE_3,
+    USER_SCRIPT_1,
+    USER_SCRIPT_FAIL,
 )
 
 RECURSUION_MAX = 15
@@ -75,15 +77,19 @@ def create_mock_project(project_dir):
     contract_dir = project_dir.joinpath('contracts')
     deploy_dir = project_dir.joinpath('deploy')
     test_dir = project_dir.joinpath('tests')
+    scripts_dir = project_dir.joinpath('scripts')
 
     project_dir.mkdir(parents=True, mode=0o755, exist_ok=True)
     contract_dir.mkdir(parents=True, mode=0o755, exist_ok=True)
     deploy_dir.mkdir(parents=True, mode=0o755, exist_ok=True)
+    scripts_dir.mkdir(parents=True, mode=0o755, exist_ok=True)
 
     write_temp_file(NETWORKS_YML_1, 'networks.yml', project_dir)
     write_temp_file(CONTRACT_SOURCE_FILE_1, 'Test.sol', contract_dir)
     write_temp_file(CONTRACT_DEPLOY_SCRIPT_1, 'deploy_main.py', deploy_dir)
     write_temp_file(PYTEST_TEST_1, 'test_testing.py', test_dir)
+    write_temp_file(USER_SCRIPT_1, 'test_success.py', scripts_dir)
+    write_temp_file(USER_SCRIPT_FAIL, 'test_fail.py', scripts_dir)
 
 
 def create_mock_project_with_libraries(project_dir):


### PR DESCRIPTION
Adds implementation for the `sb script NETWORK FILE [FILE]` command to run user scripts.

Each script must implement `main()` and can use any of these kwargs:

Currently provides the following kwargs to the function: 

- `web3` - An instantiated Web3 object
- `contracts` - An `AttrDict` of `web3.eth.Contract` objects for all known deployed contracts
- `network` - The name of the network invoked on the CLI
