### PR TITLE
Testing persistence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - pip install -r requirements.dev.txt
   - pip install -r requirements.test.txt
   - pip install -e .
+  - python setup.py install_ganache
 jobs:  
   include:
     - stage: "lint"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import sys
+import shutil
 import solidbyte
 from os import path
-from setuptools import setup, find_packages
+from setuptools import Command, setup, find_packages
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 from subprocess import check_call, CalledProcessError
@@ -46,6 +47,31 @@ class TestCommand(develop):
         except CalledProcessError as err:
             if 'non-zero' in str(err):
                 print("testing failed", file=sys.stderr)
+                sys.exit(1)
+
+
+class GanacheInstallCommand(Command):
+    """ Install ganache-cli """
+    description = 'Install ganache-cli globally'
+    user_options = [
+        ('version=', 'v', 'version of ganache to install'),
+    ]
+
+    def initialize_options(self):
+        self.version = '6.4.1'
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        if shutil.which('ganache-cli'):
+            print('Ganache already installed')
+            return
+        try:
+            check_call([shutil.which('npm'), 'install', '-g', 'ganache-cli'])
+        except CalledProcessError as err:
+            if 'non-zero' in str(err):
+                print("extract failed", file=sys.stderr)
                 sys.exit(1)
 
 
@@ -104,5 +130,6 @@ setup(
         'install': InstallCommand,
         'lint': LintCommand,
         'test': TestCommand,
+        'install_ganache': GanacheInstallCommand,
     }
 )

--- a/tests/const.py
+++ b/tests/const.py
@@ -18,6 +18,8 @@ ADDRESS_2 = '0x2c21CE1cEe5B9b1C8aA71aB09a47a5361a36beAE'
 ADDRESS_2_HASH = '0x4ff6eacd66bd565ddc5e1d660414a8f15d2bb42314b9fc2019dadbf29eefa07a'
 ADDRESS_2_NOT_CHECKSUM = '0x2c21ce1cEe5B9B1C8aA71aB09a47a5361a36beAE'
 NETWORK_ID = 999
+GANACHE_PORT = 8576  # Testing port, not to conflict with standard
+GANACHE_NETWORK_NAME = 'testganache'
 ABI_OBJ_1 = [{
   "inputs": [],
   "payable": False,
@@ -103,7 +105,10 @@ test:
 dev:
   type: auto
   autodeploy_allowed: true
-"""
+{}:
+  type: http
+  url: http://localhost:{}/
+""".format(GANACHE_NETWORK_NAME, GANACHE_PORT)
 NETWORKS_YML_2 = """# networks.yml
 ---
 test:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def execute_command_assert_no_error_success(cmd):
     return list_output
 
 
-def test_cli_integration(mock_project):
+def test_cli_integration(mock_project, ganache):
     """ Test valid CLI `accounts` commands """
 
     orig_pwd = Path.cwd()
@@ -41,125 +41,129 @@ def test_cli_integration(mock_project):
     sb = SOLIDBYTE_COMMAND
 
     with mock_project():
+        with ganache() as gopts:
 
-        TMP_KEY_DIR = TMP_DIR.joinpath('test-keys')
+            TMP_KEY_DIR = TMP_DIR.joinpath('test-keys')
 
-        # test `sb version`
-        execute_command_assert_no_error_success([sb, 'version'])
+            # test `sb version`
+            execute_command_assert_no_error_success([sb, 'version'])
 
-        # test `sb accounts create`
-        # Need to deal with stdin for the account encryption passphrase
-        execute_command_assert_no_error_success([
-            sb,
-            '-k',
-            str(TMP_KEY_DIR),
-            'accounts',
-            'create',
-            '-p',
-            PASSWORD_1,
-        ])
+            # test `sb accounts create`
+            # Need to deal with stdin for the account encryption passphrase
+            execute_command_assert_no_error_success([
+                sb,
+                '-k',
+                str(TMP_KEY_DIR),
+                'accounts',
+                'create',
+                '-p',
+                PASSWORD_1,
+            ])
 
-        # test `sb accounts list`
-        # execute_command_assert_no_error_success([sb, 'accounts', 'list'])
+            # test `sb accounts list`
+            # execute_command_assert_no_error_success([sb, 'accounts', 'list'])
 
-        # test `sb accounts [network] list`
-        accounts_output = execute_command_assert_no_error_success([
-            sb,
-            '-k',
-            str(TMP_KEY_DIR),
-            'accounts',
-            'test',
-            'list',
-        ]).decode('utf-8')
+            # test `sb accounts [network] list`
+            accounts_output = execute_command_assert_no_error_success([
+                sb,
+                '-k',
+                str(TMP_KEY_DIR),
+                'accounts',
+                gopts.network_name,
+                'list',
+            ]).decode('utf-8')
 
-        # We're going to need the default account later
-        default_account = None
-        print("accounts_output: {}".format(accounts_output))
-        for ln in accounts_output.split('\n'):
-            # 0xC4cf518bDeDe4bdbE3d98f2F8E3195c7d9DC080B
-            print("### matching {} against {}".format(ACCOUNT_MATCH_PATTERN, ln))
-            match = re.match(ACCOUNT_MATCH_PATTERN, ln)
-            if match:
-                default_account = match.group(1)
-                break
-        assert default_account is not None, "Did not find an account to use"
+            # We're going to need the default account later
+            default_account = None
+            print("accounts_output: {}".format(accounts_output))
+            for ln in accounts_output.split('\n'):
+                # 0xC4cf518bDeDe4bdbE3d98f2F8E3195c7d9DC080B
+                print("### matching {} against {}".format(ACCOUNT_MATCH_PATTERN, ln))
+                match = re.match(ACCOUNT_MATCH_PATTERN, ln)
+                if match:
+                    default_account = match.group(1)
+                    break
+            assert default_account is not None, "Did not find an account to use"
 
-        # test `sb accounts default -a [account]`
-        # Need an account for this command
-        execute_command_assert_no_error_success([
-            sb,
-            '-k',
-            str(TMP_KEY_DIR),
-            'accounts',
-            'default',
-            '-a',
-            default_account
-        ])
+            # test `sb accounts default -a [account]`
+            execute_command_assert_no_error_success([
+                sb,
+                '-k',
+                str(TMP_KEY_DIR),
+                'accounts',
+                'default',
+                '-a',
+                default_account
+            ])
 
-        # test `sb compile`
-        execute_command_assert_no_error_success([sb, 'compile'])
+            # test `sb compile`
+            execute_command_assert_no_error_success([sb, 'compile'])
 
-        # test `sb console [network]`
-        # Disabled for now.  It's interactive and no idea how to deal with that
-        # execute_command_assert_no_error_success([sb, 'console', 'test'])
+            # test `sb console [network]`
+            # Disabled for now.  It's interactive and no idea how to deal with that
+            # execute_command_assert_no_error_success([sb, 'console', 'test'])
 
-        # test `sb deploy [network] -a [account]`
-        # Disabled.  Need an account to test with
-        execute_command_assert_no_error_success([
-            sb,
-            '-k',
-            str(TMP_KEY_DIR),
-            'deploy',
-            'test',
-            '-a',
-            default_account,
-            '-p',
-            PASSWORD_1,
-        ])
+            # test `sb deploy [network] -a [account]`
+            # Disabled.  Need an account to test with
+            execute_command_assert_no_error_success([
+                sb,
+                '-k',
+                str(TMP_KEY_DIR),
+                'deploy',
+                gopts.network_name,
+                '-a',
+                default_account,
+                '-p',
+                PASSWORD_1,
+            ])
 
-        # test `sb show [network]`
-        execute_command_assert_no_error_success([sb, 'show', 'test'])
+            # test `sb show [network]`
+            execute_command_assert_no_error_success([sb, 'show', 'test'])
 
-        # test `sb test [network]`
-        # TODO: Currently throwing an exception.  Look into it.
-        execute_command_assert_no_error_success([
-            sb,
-            '-k',
-            str(TMP_KEY_DIR),
-            '-d',
-            'test',
-            '-p',
-            PASSWORD_1,
-            'test',
-        ])
+            # test `sb test [network]`
+            # TODO: Currently throwing an exception.  Look into it.
+            execute_command_assert_no_error_success([
+                sb,
+                '-k',
+                str(TMP_KEY_DIR),
+                '-d',
+                'test',
+                '-p',
+                PASSWORD_1,
+                gopts.network_name,
+            ])
 
-        # test `sb metafile backup metafile.json.bak`
-        execute_command_assert_no_error_success([sb, 'metafile', 'backup', 'metafile.json.bak'])
+            # test `sb metafile backup metafile.json.bak`
+            execute_command_assert_no_error_success([sb, 'metafile', 'backup', 'metafile.json.bak'])
 
-        # test `sb metafile cleanup --dry-run`
-        execute_command_assert_no_error_success([sb, 'metafile', 'cleanup', '--dry-run'])
+            # test `sb metafile cleanup --dry-run`
+            execute_command_assert_no_error_success([sb, 'metafile', 'cleanup', '--dry-run'])
 
-        # test `sb metafile cleanup`
-        execute_command_assert_no_error_success([sb, 'metafile', 'cleanup'])
+            # test `sb metafile cleanup`
+            execute_command_assert_no_error_success([sb, 'metafile', 'cleanup'])
 
-        # test `sb deploy -a ADDRESS NETWORK`
-        # execute_command_assert_no_error_success([
-        #     sb,
-        #     'deploy',
-        #     '-a',
-        #     default_account,
-        #     'test',
-        # ])
+            # test `sb deploy -a ADDRESS NETWORK`
+            execute_command_assert_no_error_success([
+                sb,
+                '-k',
+                str(TMP_KEY_DIR),
+                'deploy',
+                '-a',
+                default_account,
+                '-p',
+                PASSWORD_1,
+                gopts.network_name,
+            ])
 
-        # test `sb script NETWORK FILE`
-        # TODO: There's currently no persistance between the deploy command and the following
-        #       commands.  Might need to use ganache to test with instead of eth_tester.
-        # execute_command_assert_no_error_success([
-        #     sb,
-        #     'script',
-        #     'test',
-        #     'scripts/test_success.py',
-        # ])
+            # test `sb script NETWORK FILE`
+            # TODO: There's currently no persistance between the deploy command and the following
+            #       commands.  Might need to use ganache to test with instead of eth_tester.
+            execute_command_assert_no_error_success([
+                sb,
+                'script',
+                gopts.network_name,
+                'scripts/test_success.py',
+            ])
 
     # Create a new project without the mock
     project_dir = TMP_DIR.joinpath('test-cli-init')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -166,3 +166,7 @@ def setup_venv_with_solidbyte(loc=None):
     assert setuppy.is_file(), "unable to find Solidbyte's setup.py"
     assert pip_install(python), "Install of solidbyte failed"
     return python
+
+
+def dict_to_cli_option_list(opt_dict):
+    return ['-{} {}'.format(opt, opt_dict[opt]).strip() for opt in opt_dict.keys()]


### PR DESCRIPTION
Some of the Solidbyte tests(CLI integration, especially) need chain persistence to run properly.  Added a `setup.py` command to install Ganache globally, and added a pytest fixture to provide a Ganache instance.

Ref: #10