### PR TITLE
Adds solidity-parser for interface checking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ vyper==0.1.0b9
 # If not specified, causes issues for some reason
 py-ecc==1.4.7
 eth_typing==1.3.0
+# Solidity
+solidity-parser>=0.0.3

--- a/solidbyte/compile/solidity.py
+++ b/solidbyte/compile/solidity.py
@@ -1,0 +1,29 @@
+""" Solidity compilation utilities """
+from typing import Any, Union
+from pathlib import Path
+from solidity_parser import parser
+from ..common.utils import to_path
+
+
+def parse_file(filepath: Path) -> Any:
+    return parser.parse_file(str(filepath))
+
+
+def is_solidity_interface_only(filepath: Union[str, Path]):
+    filepath = to_path(filepath)
+    source_dict = parse_file(filepath)
+    has_contract = False
+    has_interface = False
+
+    if source_dict.get('children'):
+
+        for top in source_dict['children']:
+            if top.get('kind') == 'interface':
+                has_interface = True
+            if top.get('kind') == 'contract':
+                has_contract = True
+
+    if has_interface and not has_contract:
+        return True
+
+    return False

--- a/tests/const.py
+++ b/tests/const.py
@@ -544,6 +544,39 @@ def main(contracts, deployer_account, web3, network):
     return True
 """
 
+CONTRACT_SOLIDITY_INTERFACE_NAME = "ITest"
+CONTRACT_SOLIDITY_IMPLEMENTER_NAME = "Implementer"
+CONTRACT_SOLIDITY_IMPLEMENTER = """pragma solidity ^0.5.2;
+
+import './{}.sol';
+
+contract {} is {} {{
+    uint256 public count;
+
+    function addOne(uint256 val) external
+    {{
+        count += val;
+    }}
+
+    function getCount() external view returns (uint256)
+    {{
+        return count;
+    }}
+}}
+""".format(
+    CONTRACT_SOLIDITY_INTERFACE_NAME,
+    CONTRACT_SOLIDITY_IMPLEMENTER_NAME,
+    CONTRACT_SOLIDITY_INTERFACE_NAME
+)
+
+CONTRACT_SOLIDITY_INTERFACE = """pragma solidity ^0.5.2;
+
+interface {} {{
+    function addOne(uint256 val) external;
+    function getCount() external view returns (uint256);
+}}
+""".format(CONTRACT_SOLIDITY_INTERFACE_NAME)
+
 USER_SCRIPT_1 = """
 
 def main(contracts):

--- a/tests/test_solidity.py
+++ b/tests/test_solidity.py
@@ -1,0 +1,71 @@
+""" Tests for vyper integration.
+"""
+import json
+from solidbyte.compile import Compiler
+from .const import (
+    CONTRACT_SOLIDITY_IMPLEMENTER_NAME,
+    CONTRACT_SOLIDITY_INTERFACE_NAME,
+    CONTRACT_SOLIDITY_IMPLEMENTER,
+    CONTRACT_SOLIDITY_INTERFACE,
+)
+from .utils import (
+    write_temp_file,
+    get_file_extension,
+    is_hex,
+)
+
+
+def test_compile_solidity_with_interface(temp_dir):
+    """ test a simple compile """
+    with temp_dir() as test_dir:
+        contract_dir = test_dir.joinpath('contracts')
+        print("CONTRACTTTTTTTTTTTTTTTTTT: ", CONTRACT_SOLIDITY_IMPLEMENTER)
+        contract_file = write_temp_file(
+            CONTRACT_SOLIDITY_IMPLEMENTER,
+            '{}.sol'.format(CONTRACT_SOLIDITY_IMPLEMENTER_NAME),
+            contract_dir
+        )
+        write_temp_file(
+            CONTRACT_SOLIDITY_INTERFACE,
+            '{}.sol'.format(CONTRACT_SOLIDITY_INTERFACE_NAME),
+            contract_dir
+        )
+
+        compiler = Compiler(test_dir)
+        compiler.compile(contract_file.name)
+
+        # Make sure the compiler is putting output files in the right location
+        compiled_dir = test_dir.joinpath('build', CONTRACT_SOLIDITY_IMPLEMENTER_NAME)
+        assert compiled_dir.exists() and compiled_dir.is_dir()
+
+        # Make sure the compiler created the correct files
+        for fil in compiled_dir.iterdir():
+
+            ext = get_file_extension(fil)
+
+            assert ext in ('bin', 'abi'), "Invalid extensions"
+            assert fil.name in (
+                '{}.bin'.format(CONTRACT_SOLIDITY_IMPLEMENTER_NAME),
+                '{}.abi'.format(CONTRACT_SOLIDITY_IMPLEMENTER_NAME),
+                '{}.bin'.format(CONTRACT_SOLIDITY_INTERFACE_NAME),
+                '{}.abi'.format(CONTRACT_SOLIDITY_INTERFACE_NAME),
+            ), (
+                "Invalid filename"
+            )
+
+            if ext == 'bin':
+
+                # Interface won't have binary
+                if CONTRACT_SOLIDITY_IMPLEMENTER_NAME in fil.name:
+
+                    fil_cont = fil.read_text()
+                    assert is_hex(fil_cont), "binary file is not hex"
+
+            elif ext == 'abi':
+
+                fil_cont = fil.read_text()
+
+                try:
+                    json.loads(fil_cont)
+                except json.decoder.JSONDecodeError:
+                    assert False, "Invalid JSON in ABI file"


### PR DESCRIPTION
This adds the [`solidity-parser` package](https://github.com/ConsenSys/python-solidity-parser) to check for interfaces before compiling.